### PR TITLE
fix: correctly pin to appropriate commit for 1.38.48

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM ubuntu:xenial
 
-ARG TAG=3.1.44
-ARG COMMIT=a896e3d066448b3530dbcaa48869fafefd738f57
+ARG COMMIT=7f9af7bd1af0b4c90abe9fce1b7c32566c0722f6
 ARG VERSION=1.38.48
 
 SHELL ["/bin/bash", "-c"]
 
 RUN apt-get update \
   && apt-get install -y git python cmake build-essential openjdk-9-jre-headless \
-  && git clone --single-branch --branch "$TAG" --depth 1 https://github.com/juj/emsdk.git /root/emsdk \
+  && git clone --single-branch --branch "$VERSION" --depth 1 https://github.com/juj/emsdk.git /root/emsdk \
   && cd /root/emsdk \
   && git checkout "$COMMIT" \
   && /root/emsdk/emsdk install ${VERSION} \


### PR DESCRIPTION
Latest master of emscripten doesn't work with our code. This pins it to the same version we install, and it seems to work (no more errors when building).

From a timeline perspective, Guten's commit is in September 2020 and the commit I'm pinning to here is older than that and was unlikely master at the time, but it seemed more logical to pin to that specific version instead of a random commit that was master at the time.